### PR TITLE
implement GDataConstructor for `V1`/`NoConstructors`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,8 @@ let
   inherit (nixpkgs) pkgs;
 
   f = { mkDerivation, base, containers, directory, errors, filepath
-      , generic-deriving, lens, mtl, stdenv, text, transformers
+      , generic-deriving, lens, mtl, stdenv, text, transformers, wl-pprint-text
+      , hspec, hspec-expectations-pretty-diff
       }:
       mkDerivation {
         pname = "purescript-bridge";
@@ -13,7 +14,7 @@ let
         src = ./.;
         libraryHaskellDepends = [
           base containers directory errors filepath generic-deriving lens mtl
-          text transformers
+          text transformers wl-pprint-text hspec hspec-expectations-pretty-diff
         ];
         description = "Generate PureScript data types from Haskell data types";
         license = stdenv.lib.licenses.bsd3;

--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -171,15 +171,17 @@ sumTypeToTypeDecls :: Switches.Settings -> SumType 'PureScript -> Doc
 sumTypeToTypeDecls settings (SumType t cs is) =
   vsep $
   concat
-    [ [ dataOrNewtype <+> typeInfoToDoc True t
-      , indent
+    [ [ dataOrNewtype <+> typeInfoToDoc True t ]
+      -- if there is no constructors, we only generate a left hand side (void-type)
+    , if cs == [] then []
+        else
+        [ indent
           2
           (encloseVsep
-             ("=" <> space)
-             mempty
-             ("|" <> space)
-             (constructorToDoc <$> cs))
-      ]
+            ("=" <> space)
+            mempty
+            ("|" <> space)
+            (constructorToDoc <$> cs))]
     , [line]
     , instances settings (SumType t cs (filter genForeign is))
     ]
@@ -307,7 +309,7 @@ instances settings st@(SumType t cs is) = go <$> is
           | Switches.genericsGenRep settings = " _"
           | otherwise = ""
         postfix _ = ""
-    isEnum = all isNoArgConstructor cs
+    isEnum = cs /= [] && all isNoArgConstructor cs
     isNoArgConstructor c = (c ^. sigValues) == Left []
 
 recordUpdateDoc :: [(Doc, Doc)] -> Doc

--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -142,6 +142,9 @@ class GDataConstructor f where
 class GRecordEntry f where
   gToRecordEntries :: f a -> [RecordEntry 'Haskell]
 
+instance GDataConstructor V1 where
+  gToConstructors _ = []
+
 instance (Datatype a, GDataConstructor c) => GDataConstructor (D1 a c) where
   gToConstructors (M1 c) = gToConstructors c
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -317,6 +317,23 @@ allTests = do
               , "--------------------------------------------------------------------------------"
               ]
        in recTypeText `shouldRender` txt
+    it
+      "tests generation for haskell data type with no constructors" $
+      let recType =
+            bridgeSumType
+              (buildBridge defaultBridge)
+              (mkSumType (Proxy :: Proxy VoidType))
+          recTypeText = sumTypeToDoc settings recType
+          txt =
+            T.unlines
+              [ "data VoidType"
+              , ""
+              , ""
+              , "derive instance genericVoidType :: Generic VoidType"
+              , "--------------------------------------------------------------------------------"
+              , "--------------------------------------------------------------------------------"
+              ]
+       in recTypeText `shouldRender` txt
     it "tests generation of newtypes for haskell data type with one argument" $
       let recType =
             bridgeSumType

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -64,6 +64,9 @@ data TwoRecords
   , _srd :: [Int]
   } deriving(Generic, Typeable, Show)
 
+data VoidType
+  deriving (Generic, Typeable)
+
 newtype SomeNewtype = SomeNewtype Int
   deriving (Generic, Typeable, Show)
 


### PR DESCRIPTION
Implements support for bridging `Void`-like phantom types

It should be possible to bridge types that do not have any
constructors, e.g. ones that are used as phantom data types:

In Haskell:

```
data Phantom
```

(no right hand side)


I am not 100% sure I correctly handled the cases for all generators, I adjusted the tests that were there (which cover `Generic` and `Lens`, but not `Encode`/`Decode`. `Lens` I don’t know if it makes sense to implement any, probably not. `Encode` and `Decode` should be covered by using the `genericDecode` generator (see empty list check in `isEnum`).

cc @krisajenkins 